### PR TITLE
Add daySize to daypickerRangeController and classname to other components

### DIFF
--- a/src/BsReactDates__DateRangePicker.re
+++ b/src/BsReactDates__DateRangePicker.re
@@ -5,6 +5,7 @@ open MomentRe;
 [@bs.obj]
 external makeProps:
   (
+    ~className: string=?,
     ~onDatesChange: Dates.tJs => unit,
     ~onFocusChange: Js.nullable(string) => unit,
     ~startDate: Moment.t=?,
@@ -87,6 +88,7 @@ let dateRangePicker = ReasonReact.statelessComponent("DateRangePicker");
 
 let make =
     (
+      ~className=?,
       ~onDatesChange,
       ~onFocusChange,
       ~startDate=?,
@@ -163,6 +165,7 @@ let make =
           ~reactClass=dateRangePickerAbs,
           ~props=
             makeProps(
+              ~className?,
               ~onDatesChange=handleDatesChange,
               ~onFocusChange=handleFocusChange,
               ~startDate?,

--- a/src/BsReactDates__DateRangePickerPhrases.re
+++ b/src/BsReactDates__DateRangePickerPhrases.re
@@ -1,8 +1,9 @@
 type t;
 
 [@bs.obj]
-external make:
+external make :
   (
+    ~className: string=?,
     ~closeDatePicker: string,
     ~clearDates: string,
     ~focusStartDate: string,

--- a/src/BsReactDates__DayPickerRangeController.re
+++ b/src/BsReactDates__DayPickerRangeController.re
@@ -4,6 +4,7 @@ open MomentRe;
 [@bs.obj]
 external makeProps:
   (
+    ~className: string=?,
     ~onDatesChange: Dates.tJs => unit,
     ~onFocusChange: Js.nullable(string) => unit,
     ~startDate: Moment.t=?,
@@ -20,6 +21,7 @@ external makeProps:
     ~keepOpenOnDateSelect: bool=?,
     ~noBorder: bool=?,
     ~hideKeyboardShortcutsPanel: bool=?,
+    ~daySize: int=?,
     /* navigation related props */
     ~navPrev: ReasonReact.reactElement=?,
     ~navNext: ReasonReact.reactElement=?,
@@ -52,6 +54,7 @@ let dayPickerRangeController =
 
 let make =
     (
+      ~className=?,
       ~onDatesChange,
       ~onFocusChange,
       ~startDate=?,
@@ -67,6 +70,7 @@ let make =
       ~keepOpenOnDateSelect=?,
       ~noBorder=?,
       ~hideKeyboardShortcutsPanel=?,
+      ~daySize=?,
       ~navPrev=?,
       ~navNext=?,
       ~onPrevMonthClick=?,
@@ -94,6 +98,7 @@ let make =
           ~reactClass=dayPickerRangeControllerAbs,
           ~props=
             makeProps(
+              ~className?,
               ~onDatesChange=handleDatesChange,
               ~onFocusChange=handleFocusChange,
               ~startDate?,
@@ -109,6 +114,7 @@ let make =
               ~keepOpenOnDateSelect?,
               ~noBorder?,
               ~hideKeyboardShortcutsPanel?,
+              ~daySize?,
               ~navPrev?,
               ~navNext?,
               ~onPrevMonthClick?,

--- a/src/BsReactDates__SingleDatePicker.re
+++ b/src/BsReactDates__SingleDatePicker.re
@@ -4,6 +4,7 @@ open MomentRe;
 [@bs.obj]
 external makeProps:
   (
+    ~className: string=?,
     ~onDateChange: Moment.t => unit,
     ~onFocusChange: {. "focused": bool} => unit,
     ~focused: bool,
@@ -83,6 +84,7 @@ let singleDatePicker = ReasonReact.statelessComponent("SingleDatePicker");
 
 let make =
     (
+      ~className=?,
       ~date=?,
       ~onDateChange,
       ~onFocusChange,
@@ -145,6 +147,7 @@ let make =
         ~reactClass=singleDatePickerAbs,
         ~props=
           makeProps(
+            ~className?,
             ~onDateChange,
             ~onFocusChange=isFocussed => onFocusChange(isFocussed##focused),
             ~focused,


### PR DESCRIPTION
fix daySize is missing from daypickerRangeController, therefore daypickerRangeController is not sizeable.
