### PR TITLE
Add compatibility with reason-react 0.14

### DIFF
--- a/melange-react-dates.opam
+++ b/melange-react-dates.opam
@@ -36,4 +36,6 @@ depexts: [
 ]
 pin-depends: [
   [ "melange-moment.dev"    "git+https://github.com/ahrefs/melange-moment.git#646da3e7014e61dc7b543593b10eef3269d38ce3" ]
+  [ "reason-react.dev"      "git+https://github.com/reasonml/reason-react.git#7ca984c9a406b01e906fda1898f705f135fad202" ]
+  [ "reason-react-ppx.dev"  "git+https://github.com/reasonml/reason-react.git#7ca984c9a406b01e906fda1898f705f135fad202" ]
 ]

--- a/melange-react-dates.opam
+++ b/melange-react-dates.opam
@@ -12,8 +12,8 @@ depends: [
   "melange" {>= "2.0.0"}
   "reason"
   "melange-moment"
-  "reason-react"
-  "reason-react-ppx"
+  "reason-react" {>= "0.14.0"}
+  "reason-react-ppx" {>= "0.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/src/DayPickerRangeController.re
+++ b/src/DayPickerRangeController.re
@@ -20,7 +20,7 @@ external make:
     ~withPortal: bool=?,
     ~initialVisibleMonth: unit => Moment.t=?,
     ~renderCalendarInfo: unit => StrOrNode.t=?,
-    ~onOutsideClick: ReactEvent.Mouse.t => unit=?,
+    ~onOutsideClick: React.Event.Mouse.t => unit=?,
     ~keepOpenOnDateSelect: bool=?,
     ~noBorder: bool=?,
     // navigation related props


### PR DESCRIPTION
Previously based on #32.

Updates the library to be compatible with reason-react 0.14.
