### PR TITLE
pin melange-moment to branch

### DIFF
--- a/melange-react-dates.opam
+++ b/melange-react-dates.opam
@@ -34,3 +34,6 @@ dev-repo: "git+https://github.com/ahrefs/melange-react-dates.git"
 depexts: [
   ["react-dates"] {npm-version = "^21.8.0"}
 ]
+pin-depends: [
+  [ "melange-moment.dev" "git+https://github.com/ahrefs/melange-moment.git#0c11b2fdf0525686bf37c85be41f62c5e8d8ba1a" ]
+]

--- a/src/DateRangePicker.re
+++ b/src/DateRangePicker.re
@@ -1,7 +1,7 @@
 // https://github.com/airbnb/react-dates#daterangepicker
 
 open Utils;
-module Moment = MomentRe.Moment;
+module Moment = MomentReMjs.Moment;
 
 [@mel.module "react-dates"] [@react.component]
 external make:

--- a/src/DayPickerRangeController.re
+++ b/src/DayPickerRangeController.re
@@ -1,7 +1,7 @@
 // https://github.com/airbnb/react-dates#daypickerrangecontroller
 
 open Utils;
-module Moment = MomentRe.Moment;
+module Moment = MomentReMjs.Moment;
 
 [@mel.module "react-dates"] [@react.component]
 external make:

--- a/src/DayPickerSingleDateController.re
+++ b/src/DayPickerSingleDateController.re
@@ -1,5 +1,5 @@
 open Utils;
-module Moment = MomentRe.Moment;
+module Moment = MomentReMjs.Moment;
 
 [@mel.module "react-dates"] [@react.component]
 external make:

--- a/src/SingleDatePicker.re
+++ b/src/SingleDatePicker.re
@@ -1,5 +1,5 @@
 open Utils;
-module Moment = MomentRe.Moment;
+module Moment = MomentReMjs.Moment;
 
 [@mel.module "react-dates"] [@react.component]
 external make:

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -1,5 +1,5 @@
 open Belt;
-module Moment = MomentRe.Moment;
+module Moment = MomentReMjs.Moment;
 
 /* Have to call initialize in order this to work
  * https://github.com/airbnb/react-dates#initialize */

--- a/src/dune
+++ b/src/dune
@@ -2,5 +2,5 @@
  (name reactDates)
  (public_name melange-react-dates)
  (modes melange)
- (libraries melange-moment reason-react)
+ (libraries melange-moment.mjs reason-react)
  (preprocess (pps melange.ppx reason-react-ppx)))


### PR DESCRIPTION
DO NOT MERGE.

Copy of https://github.com/ahrefs/melange-react-dates/pull/34 with melange v2 update. Creating a new PR as I could not push to original branch.

This PR pins dep to specific melange-moment for an experiment with esbuild.